### PR TITLE
Fix TypeScript config and missing component

### DIFF
--- a/src/components/AsteroidCard/AsteroidCardDino/DinoImage.tsx
+++ b/src/components/AsteroidCard/AsteroidCardDino/DinoImage.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const AsteroidCardDinoImage = () => {
+  return <span role="img" aria-label="dino">🦖</span>;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,13 +4,13 @@
     "allowSyntheticDefaultImports": true,
     "jsx": "react-jsx",
     "module": "esnext",
-    "typeRoots": ["./node_modules/@types", "./src"],
+    "typeRoots": ["./node_modules/@types"],
     "moduleResolution": "node",
     "lib": [
       "dom",
       "esnext"
     ],
-    "target": "esnext",
+    "target": "esnext"
 
   },
 


### PR DESCRIPTION
## Summary
- adjust `typeRoots` in `tsconfig.json`
- add missing `AsteroidCardDino` component

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8af136d0832985d6994346ece969